### PR TITLE
Changes {{page.content}} to {{content}} in the about.html layout

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -7,6 +7,6 @@
         <h1>TODO about layout</h1>
         <p>{{page.title}}</p>
         <img src="{{site.baseurl}}/assets/images/{{page.main_image}}" alt="Me" />
-        {{page.content}}
+        {{content}}
     </body>
 </html>


### PR DESCRIPTION
Closes issue #8.  Please note that this change was not required in each about.html template file, only the one in _layouts.
